### PR TITLE
chore: update dependencies to latest non-breaking versions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,14 +9,14 @@
       "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
-        "@aws-sdk/client-ssm": "^3.1058.0"
+        "@aws-sdk/client-ssm": "3.1063.0"
       },
       "devDependencies": {
-        "@biomejs/biome": "^2.4.16",
-        "@types/node": "^24.10.1",
-        "typescript": "^5.9.3",
-        "vite": "^8.0.16",
-        "vitest": "^4.1.8"
+        "@biomejs/biome": "2.4.16",
+        "@types/node": "24.13.0",
+        "typescript": "5.9.3",
+        "vite": "8.0.16",
+        "vitest": "4.1.8"
       },
       "engines": {
         "node": ">=24.0.0"
@@ -86,20 +86,20 @@
       }
     },
     "node_modules/@aws-sdk/client-ssm": {
-      "version": "3.1058.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-ssm/-/client-ssm-3.1058.0.tgz",
-      "integrity": "sha512-xvJ0IahS3aepnIW1400dApwH3i/eJk+ggXNbNxnjHxjN8gozTFKn80HaboT/husAImv8qzJhZG/9ZeeT7o2USg==",
+      "version": "3.1063.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-ssm/-/client-ssm-3.1063.0.tgz",
+      "integrity": "sha512-qLXNofwgCB7/3mhWR9pz/bnNgyvSxjp38SvhTazESrt3mLtX9+kMg8UOKTZol0mvZg209UVIS82xY1JhJDtGpA==",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/sha256-browser": "5.2.0",
         "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/core": "^3.974.15",
-        "@aws-sdk/credential-provider-node": "^3.972.48",
-        "@aws-sdk/types": "^3.973.9",
-        "@smithy/core": "^3.24.5",
-        "@smithy/fetch-http-handler": "^5.4.5",
-        "@smithy/node-http-handler": "^4.7.5",
-        "@smithy/types": "^4.14.2",
+        "@aws-sdk/core": "^3.974.18",
+        "@aws-sdk/credential-provider-node": "^3.972.52",
+        "@aws-sdk/types": "^3.973.11",
+        "@smithy/core": "^3.24.6",
+        "@smithy/fetch-http-handler": "^5.4.6",
+        "@smithy/node-http-handler": "^4.7.6",
+        "@smithy/types": "^4.14.3",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -107,17 +107,17 @@
       }
     },
     "node_modules/@aws-sdk/core": {
-      "version": "3.974.15",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.974.15.tgz",
-      "integrity": "sha512-UpA0rTGW/tHGITcCqHisbuuEPraYg9GG+mWmXjY5+RxZBMLGe6aL9oe0ix50LztwAcPIkGZLH0yWdMIkCM10hw==",
+      "version": "3.974.18",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.974.18.tgz",
+      "integrity": "sha512-JDYCPI0j7zGrzXTDFsLB346cxss7J/AxH7+O0MzWlqppJBEyB9Qe6TQXRL6iwLUo/xZkNv9KFmBL2hqElmwW0g==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "^3.973.9",
-        "@aws-sdk/xml-builder": "^3.972.26",
+        "@aws-sdk/types": "^3.973.11",
+        "@aws-sdk/xml-builder": "^3.972.28",
         "@aws/lambda-invoke-store": "^0.2.2",
-        "@smithy/core": "^3.24.5",
-        "@smithy/signature-v4": "^5.4.5",
-        "@smithy/types": "^4.14.2",
+        "@smithy/core": "^3.24.6",
+        "@smithy/signature-v4": "^5.4.6",
+        "@smithy/types": "^4.14.3",
         "bowser": "^2.11.0",
         "tslib": "^2.6.2"
       },
@@ -126,15 +126,15 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-env": {
-      "version": "3.972.41",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.972.41.tgz",
-      "integrity": "sha512-n1EbJ98yvPWWdHZZv8bRBMqqDQJrtgtxyJ4xLy2Uqrh25BCOZQ7nnS1CsFXvuH8r0b0KVHDZEGEH5FxmEMP8jg==",
+      "version": "3.972.44",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.972.44.tgz",
+      "integrity": "sha512-3hKJVrZ7bqXzDAXCQp+OaQ1ASN+vWstaNuEH418wQVl//cRZhqhfR9Bjk1qIWmgUGe8/D3gdO73PgidRj378EQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.974.15",
-        "@aws-sdk/types": "^3.973.9",
-        "@smithy/core": "^3.24.5",
-        "@smithy/types": "^4.14.2",
+        "@aws-sdk/core": "^3.974.18",
+        "@aws-sdk/types": "^3.973.11",
+        "@smithy/core": "^3.24.6",
+        "@smithy/types": "^4.14.3",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -142,17 +142,17 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-http": {
-      "version": "3.972.43",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.972.43.tgz",
-      "integrity": "sha512-TT76RN1NkI9WoyZqCNxOw6/WBMF7pYOTJcXbMokNFU+euSG40Kaf/t/FhDACVZWP+43wEM6ZynIPIkzS1wR1iA==",
+      "version": "3.972.46",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.972.46.tgz",
+      "integrity": "sha512-VhwC9pGAZHhiQ2xSViyOPDFqvr9aRxGCAXZtADsUhU3R65nad7y//CwynE6mQnWNR+suRlqE79W36IVayL+m1g==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.974.15",
-        "@aws-sdk/types": "^3.973.9",
-        "@smithy/core": "^3.24.5",
-        "@smithy/fetch-http-handler": "^5.4.5",
-        "@smithy/node-http-handler": "^4.7.5",
-        "@smithy/types": "^4.14.2",
+        "@aws-sdk/core": "^3.974.18",
+        "@aws-sdk/types": "^3.973.11",
+        "@smithy/core": "^3.24.6",
+        "@smithy/fetch-http-handler": "^5.4.6",
+        "@smithy/node-http-handler": "^4.7.6",
+        "@smithy/types": "^4.14.3",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -160,23 +160,23 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-ini": {
-      "version": "3.972.46",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.972.46.tgz",
-      "integrity": "sha512-hvcgcwOiS0nb2XFb5Op1Pz/vYaWz5K8kKullziGpdNRuG0NwzRXseuPt2CoBqknHGaSPVesu1aOn2OcctEYdCA==",
+      "version": "3.972.50",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.972.50.tgz",
+      "integrity": "sha512-09Xi6ovxiK42+De/qBGF71sT5F2bWgYM+1fFyDwSOpy1xpsQ5R/naIu7MVDpH6Dic36QNc8dAv4KADtMGK2JYg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.974.15",
-        "@aws-sdk/credential-provider-env": "^3.972.41",
-        "@aws-sdk/credential-provider-http": "^3.972.43",
-        "@aws-sdk/credential-provider-login": "^3.972.45",
-        "@aws-sdk/credential-provider-process": "^3.972.41",
-        "@aws-sdk/credential-provider-sso": "^3.972.45",
-        "@aws-sdk/credential-provider-web-identity": "^3.972.45",
-        "@aws-sdk/nested-clients": "^3.997.13",
-        "@aws-sdk/types": "^3.973.9",
-        "@smithy/core": "^3.24.5",
-        "@smithy/credential-provider-imds": "^4.3.6",
-        "@smithy/types": "^4.14.2",
+        "@aws-sdk/core": "^3.974.18",
+        "@aws-sdk/credential-provider-env": "^3.972.44",
+        "@aws-sdk/credential-provider-http": "^3.972.46",
+        "@aws-sdk/credential-provider-login": "^3.972.49",
+        "@aws-sdk/credential-provider-process": "^3.972.44",
+        "@aws-sdk/credential-provider-sso": "^3.972.49",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.49",
+        "@aws-sdk/nested-clients": "^3.997.17",
+        "@aws-sdk/types": "^3.973.11",
+        "@smithy/core": "^3.24.6",
+        "@smithy/credential-provider-imds": "^4.3.7",
+        "@smithy/types": "^4.14.3",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -184,16 +184,16 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-login": {
-      "version": "3.972.45",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-login/-/credential-provider-login-3.972.45.tgz",
-      "integrity": "sha512-MZQv4SNjByk1iOKmrqmzcUF/uCB05wjvEHyXKxmGQTUANTIVayX6HPUF0bzkWLvtnkH7sAn9kUCfkXbSpj9sDA==",
+      "version": "3.972.49",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-login/-/credential-provider-login-3.972.49.tgz",
+      "integrity": "sha512-EfJF/1Fh9mI4pZyoheU2RY9xUhTcugIZNkD63+orXMkYj/QXacJNbKVDUK90Yv5hE+aX+rt9J/EZ9Qr3vKOa7g==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.974.15",
-        "@aws-sdk/nested-clients": "^3.997.13",
-        "@aws-sdk/types": "^3.973.9",
-        "@smithy/core": "^3.24.5",
-        "@smithy/types": "^4.14.2",
+        "@aws-sdk/core": "^3.974.18",
+        "@aws-sdk/nested-clients": "^3.997.17",
+        "@aws-sdk/types": "^3.973.11",
+        "@smithy/core": "^3.24.6",
+        "@smithy/types": "^4.14.3",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -201,21 +201,21 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-node": {
-      "version": "3.972.48",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.48.tgz",
-      "integrity": "sha512-QIbtJP0olSLZ2ImEu636pP+7JJbPfaL3xSJIFXhu472CWuondCc4bGOa8OeyhOFet8z4H1D/ZFKXc39FboWwYA==",
+      "version": "3.972.52",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.52.tgz",
+      "integrity": "sha512-7QX+PbyiWBEOVipJq8Nke/TqXT6lAPLE7fvTaopa39/IVWuLfS+Fzdy71sZJONf/mLGgmtj6aU17+REw3+aRrw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/credential-provider-env": "^3.972.41",
-        "@aws-sdk/credential-provider-http": "^3.972.43",
-        "@aws-sdk/credential-provider-ini": "^3.972.46",
-        "@aws-sdk/credential-provider-process": "^3.972.41",
-        "@aws-sdk/credential-provider-sso": "^3.972.45",
-        "@aws-sdk/credential-provider-web-identity": "^3.972.45",
-        "@aws-sdk/types": "^3.973.9",
-        "@smithy/core": "^3.24.5",
-        "@smithy/credential-provider-imds": "^4.3.6",
-        "@smithy/types": "^4.14.2",
+        "@aws-sdk/credential-provider-env": "^3.972.44",
+        "@aws-sdk/credential-provider-http": "^3.972.46",
+        "@aws-sdk/credential-provider-ini": "^3.972.50",
+        "@aws-sdk/credential-provider-process": "^3.972.44",
+        "@aws-sdk/credential-provider-sso": "^3.972.49",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.49",
+        "@aws-sdk/types": "^3.973.11",
+        "@smithy/core": "^3.24.6",
+        "@smithy/credential-provider-imds": "^4.3.7",
+        "@smithy/types": "^4.14.3",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -223,15 +223,15 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-process": {
-      "version": "3.972.41",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.972.41.tgz",
-      "integrity": "sha512-7I/n1zkysouLOWvkEhjNEP4vMnD2v4kzzr3/3QBdrripEpn7ap1/I5DF3Hou1SUqkKWo1f3oPGMyFAA1FAMvsQ==",
+      "version": "3.972.44",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.972.44.tgz",
+      "integrity": "sha512-V+UUhZpRP7QDRhi+qgBDisM9tUBnYmMje8Bk77A6MZsfeGeGdMsQXmaHP1CDYFcept0o/Rz5g2Y0TMeVlG9dzg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.974.15",
-        "@aws-sdk/types": "^3.973.9",
-        "@smithy/core": "^3.24.5",
-        "@smithy/types": "^4.14.2",
+        "@aws-sdk/core": "^3.974.18",
+        "@aws-sdk/types": "^3.973.11",
+        "@smithy/core": "^3.24.6",
+        "@smithy/types": "^4.14.3",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -239,17 +239,17 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-sso": {
-      "version": "3.972.45",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.972.45.tgz",
-      "integrity": "sha512-oHgbz/eFD8IKiksqDsz9ZMU4A59BpQq4QwJedBnGD80ZqYcHPPHZBwjBnxLVkB7iRVVHWpDclR8yWdD2PkQIUA==",
+      "version": "3.972.49",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.972.49.tgz",
+      "integrity": "sha512-9QqOYGuh5tZ76OzaT68kwI78AH+5lS/uZGGvkfxb3fc8FzRrIz2jOufNTliEBEeSAwmgK2rWLNsK+IB3zbtNPA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.974.15",
-        "@aws-sdk/nested-clients": "^3.997.13",
-        "@aws-sdk/token-providers": "3.1056.0",
-        "@aws-sdk/types": "^3.973.9",
-        "@smithy/core": "^3.24.5",
-        "@smithy/types": "^4.14.2",
+        "@aws-sdk/core": "^3.974.18",
+        "@aws-sdk/nested-clients": "^3.997.17",
+        "@aws-sdk/token-providers": "3.1063.0",
+        "@aws-sdk/types": "^3.973.11",
+        "@smithy/core": "^3.24.6",
+        "@smithy/types": "^4.14.3",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -257,16 +257,16 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-web-identity": {
-      "version": "3.972.45",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.972.45.tgz",
-      "integrity": "sha512-CDhzKdb2onv5bpnjn/acgdNmJOQthPDLsPizU7rZflsEcgMMp8Mlri+U5hdxf8ldvZJpvM3vLU6D56vfJm5AMQ==",
+      "version": "3.972.49",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.972.49.tgz",
+      "integrity": "sha512-IYx1lN38MnnPXv+NBLpuATu0cZakbZ321TAfjW+aVkw7HIJF38YnEwdeEO55MSl3pl7hIX1IvvnD6EmnAzmAJw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.974.15",
-        "@aws-sdk/nested-clients": "^3.997.13",
-        "@aws-sdk/types": "^3.973.9",
-        "@smithy/core": "^3.24.5",
-        "@smithy/types": "^4.14.2",
+        "@aws-sdk/core": "^3.974.18",
+        "@aws-sdk/nested-clients": "^3.997.17",
+        "@aws-sdk/types": "^3.973.11",
+        "@smithy/core": "^3.24.6",
+        "@smithy/types": "^4.14.3",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -274,20 +274,20 @@
       }
     },
     "node_modules/@aws-sdk/nested-clients": {
-      "version": "3.997.13",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.997.13.tgz",
-      "integrity": "sha512-2pA6eyb5nSo/ZD2cayhOTEMoGQYgspq0RI05GDLkzQ3ajZ6isS6waV6E92Am/hz4LIlLUTrbwPLurJ/fuiHvkg==",
+      "version": "3.997.17",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.997.17.tgz",
+      "integrity": "sha512-lDRgraoTfKRawUyc176Ow93mrNrOho/x+EoK4C+lKU+vKkHWhNhzvSMVAx0WEJUJoeQxxDN5ZdKMfiGEyNejig==",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/sha256-browser": "5.2.0",
         "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/core": "^3.974.15",
-        "@aws-sdk/signature-v4-multi-region": "^3.996.30",
-        "@aws-sdk/types": "^3.973.9",
-        "@smithy/core": "^3.24.5",
-        "@smithy/fetch-http-handler": "^5.4.5",
-        "@smithy/node-http-handler": "^4.7.5",
-        "@smithy/types": "^4.14.2",
+        "@aws-sdk/core": "^3.974.18",
+        "@aws-sdk/signature-v4-multi-region": "^3.996.32",
+        "@aws-sdk/types": "^3.973.11",
+        "@smithy/core": "^3.24.6",
+        "@smithy/fetch-http-handler": "^5.4.6",
+        "@smithy/node-http-handler": "^4.7.6",
+        "@smithy/types": "^4.14.3",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -295,14 +295,14 @@
       }
     },
     "node_modules/@aws-sdk/signature-v4-multi-region": {
-      "version": "3.996.30",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.996.30.tgz",
-      "integrity": "sha512-HULDLMVzkmTSEv6//7kx2kRevp/VYUpm8hJNNFbmhxDn0fUiGTxVcM9yg31TukvTq8nyOBDUN2gH0o5IRbKjdw==",
+      "version": "3.996.32",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.996.32.tgz",
+      "integrity": "sha512-llvApLcsWtmRFhG2wT3WIp1CmDeRaIYutqty1ZZXoMzK7TiJ6MOLOimk9eXUS8PwgG4ew4pa4QAbt0lfhn++1w==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "^3.973.9",
-        "@smithy/signature-v4": "^5.4.5",
-        "@smithy/types": "^4.14.2",
+        "@aws-sdk/types": "^3.973.11",
+        "@smithy/signature-v4": "^5.4.6",
+        "@smithy/types": "^4.14.3",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -310,16 +310,16 @@
       }
     },
     "node_modules/@aws-sdk/token-providers": {
-      "version": "3.1056.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1056.0.tgz",
-      "integrity": "sha512-81duvlltQlsfn5K+o8zILcystBRdbT1G2JJYVCML5NZHBz4CL/zf+sAemCtBh/uh6RQUMyInGeZLQ7/8igZhbA==",
+      "version": "3.1063.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1063.0.tgz",
+      "integrity": "sha512-nYDaWWdzjKiDP5xj8k4oUgcYd4WPgzfAOgdU5vJsaqH/07Dfvm7ffisHCFJ+NEl7kUC9JEIUxh0kznvenbo3NQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.974.15",
-        "@aws-sdk/nested-clients": "^3.997.13",
-        "@aws-sdk/types": "^3.973.9",
-        "@smithy/core": "^3.24.5",
-        "@smithy/types": "^4.14.2",
+        "@aws-sdk/core": "^3.974.18",
+        "@aws-sdk/nested-clients": "^3.997.17",
+        "@aws-sdk/types": "^3.973.11",
+        "@smithy/core": "^3.24.6",
+        "@smithy/types": "^4.14.3",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -327,12 +327,12 @@
       }
     },
     "node_modules/@aws-sdk/types": {
-      "version": "3.973.9",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.973.9.tgz",
-      "integrity": "sha512-kuBfgQVdcz5Bmapc4A13YbpVw/pXkesfhetcFYwbntqas8sF41OHyd4o28+/TG2ZQdHBsv90Lsu5y6oitvYCdg==",
+      "version": "3.973.11",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.973.11.tgz",
+      "integrity": "sha512-YjS0qFuECClRh4qhEyW8XagW0fwEPBeZ1cfsW/gU73Kh/ExFILxbzxOfPCmzF/2DwEvhvsHYt0b0qnvStwKYrg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.14.2",
+        "@smithy/types": "^4.14.3",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -340,9 +340,9 @@
       }
     },
     "node_modules/@aws-sdk/util-locate-window": {
-      "version": "3.965.5",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-locate-window/-/util-locate-window-3.965.5.tgz",
-      "integrity": "sha512-WhlJNNINQB+9qtLtZJcpQdgZw3SCDCpXdUJP7cToGwHbCWCnRckGlc6Bx/OhWwIYFNAn+FIydY8SZ0QmVu3xTQ==",
+      "version": "3.965.6",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-locate-window/-/util-locate-window-3.965.6.tgz",
+      "integrity": "sha512-ZfHjfwSzeXj+Lg9AK5ZNmeDkXev6V+w2tn1t4kgDdRtUaRCthepTQiFwbD06EF9oNGH4LaLg+Mb6U16Ypv5bSw==",
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.6.2"
@@ -352,12 +352,12 @@
       }
     },
     "node_modules/@aws-sdk/xml-builder": {
-      "version": "3.972.26",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.972.26.tgz",
-      "integrity": "sha512-cDbrqvDS73whl6YAPSPq0U6whzG6UWI9PuWh0wrUuGoZexhWEqhdunbukV7iBoaWnFV1AODutM5hOD6rtn439g==",
+      "version": "3.972.28",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.972.28.tgz",
+      "integrity": "sha512-lI/l3c/vPvsxmspzV63NfS3x9q4CkMmdhJy4QiM+NThAufVkDvi/PZZQ6xETnICL0UD7jI808pY83gllf86RFg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.14.2",
+        "@smithy/types": "^4.14.3",
         "fast-xml-parser": "5.7.3",
         "tslib": "^2.6.2"
       },
@@ -898,9 +898,9 @@
       }
     },
     "node_modules/@smithy/credential-provider-imds": {
-      "version": "4.3.7",
-      "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-4.3.7.tgz",
-      "integrity": "sha512-xj8gq/bjFABAh6qWPSDCYcY3kzQIm4b561C+YnHH4zGq8rOgzQ3Shk+JGlpUxSd41UGiO6FkLdUCtNX1FAeHgg==",
+      "version": "4.3.8",
+      "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-4.3.8.tgz",
+      "integrity": "sha512-5cAM+KZC02sTqDt6NaLXyu50M/GNMd1eTzDVR8Lb0BBsVtu7RWHo47VPPEEv1vt3Yub6uzr+M5FHC+GtoT0USg==",
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/core": "^3.24.6",
@@ -938,9 +938,9 @@
       }
     },
     "node_modules/@smithy/node-http-handler": {
-      "version": "4.7.6",
-      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.7.6.tgz",
-      "integrity": "sha512-3fya8i7GrJilQouk4cZJKdy5k8MWQBpjfXrRNaXDedH8r779tr0jcxyH3+yoTmsluc2+vF4S343yFbnvu8ExDQ==",
+      "version": "4.7.7",
+      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.7.7.tgz",
+      "integrity": "sha512-ZAFvHXrEk6K180EVhmZVg8GU5pUH5BSFqRs27JW3j1qEFx9YyYwWFx17x/MHcjALYimGAji7qEOlF1++be+G5A==",
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/core": "^3.24.6",
@@ -1047,13 +1047,13 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "24.10.1",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.10.1.tgz",
-      "integrity": "sha512-GNWcUTRBgIRJD5zj+Tq0fKOJ5XZajIiBroOF0yvj2bSU1WvNdYS/dn9UxwsujGW4JX06dnHyjV2y9rRaybH0iQ==",
+      "version": "24.13.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.13.0.tgz",
+      "integrity": "sha512-5vtOqGQr4NJKeEzV441FcOi2MeG9UTWq9LqVLGneDdu4vlX17H8kQ2PA2UmNwCUGPVDj4oBjNhS7ReVEIWJJrg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "undici-types": "~7.16.0"
+        "undici-types": "~7.18.0"
       }
     },
     "node_modules/@vitest/expect": {
@@ -1823,9 +1823,9 @@
       }
     },
     "node_modules/undici-types": {
-      "version": "7.16.0",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
-      "integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
+      "version": "7.18.2",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.18.2.tgz",
+      "integrity": "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==",
       "dev": true,
       "license": "MIT"
     },

--- a/package.json
+++ b/package.json
@@ -38,14 +38,14 @@
   },
   "homepage": "https://github.com/domengabrovsek/telegram-notify-bot#readme",
   "devDependencies": {
-    "@biomejs/biome": "^2.4.16",
-    "@types/node": "^24.10.1",
-    "typescript": "^5.9.3",
-    "vite": "^8.0.16",
-    "vitest": "^4.1.8"
+    "@biomejs/biome": "2.4.16",
+    "@types/node": "24.13.0",
+    "typescript": "5.9.3",
+    "vite": "8.0.16",
+    "vitest": "4.1.8"
   },
   "dependencies": {
-    "@aws-sdk/client-ssm": "^3.1058.0"
+    "@aws-sdk/client-ssm": "3.1063.0"
   },
   "engines": {
     "node": ">=24.0.0"


### PR DESCRIPTION
## Summary

- `@aws-sdk/client-ssm` 3.1058.0 → 3.1063.0
- `@types/node` 24.10.1 → 24.13.0
- Pin all versions exactly (drop `^`/`~` prefixes from `package.json`)

(Dependabot already merged the other minor bumps for `vite`, `vitest`, and `@biomejs/biome` on master.)

## Test plan

- [x] `npm install` — 0 vulnerabilities
- [x] `npm run lint` — passes
- [x] `npm run typecheck` — passes
- [x] `npm run build` — passes (vite 8)
- [x] `npm test` — 52/52 pass on vitest 4
- [ ] CI to verify