### PR TITLE
chore: drop master from workflow triggers

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -5,10 +5,10 @@ permissions:
   id-token: write   # Required for AWS OIDC authentication
   contents: read    # Required to checkout repository
 
-# Trigger workflow on push to master branch
+# Trigger workflow on push to main branch
 on:
   push:
-    branches: [ master ]
+    branches: [ main ]
   # Allow manual workflow runs for testing
   workflow_dispatch:
 

--- a/.github/workflows/notifications.yml
+++ b/.github/workflows/notifications.yml
@@ -9,7 +9,7 @@ name: Notifications
 on:
   pull_request:
     types: [opened, closed, synchronize, labeled, review_requested]
-    branches: [master]
+    branches: [main]
   issue_comment:
     types: [created]
   pull_request_review:

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -8,7 +8,7 @@ name: Pull Request
 
 on:
   pull_request:
-    branches: [master]
+    branches: [main]
   workflow_dispatch:
 
 concurrency:


### PR DESCRIPTION
## Summary

- Default branch was renamed `master` → `main` on GitHub
- Update workflow triggers to reference `main` only
  - `deploy.yml`: push trigger and the leading comment
  - `notifications.yml`: PR branch filter
  - `pull-request.yml`: PR branch filter

External-repo refs (`domengabrovsek/github-actions/.github/workflows/*.yml@master`) are left untouched — separate repo, separate rename.

## Test plan

- [ ] CI on this PR triggers (proves `branches: [main]` works)