### PR TITLE
chore: upgrade typescript to 6.0.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
       "devDependencies": {
         "@biomejs/biome": "2.4.16",
         "@types/node": "24.13.0",
-        "typescript": "5.9.3",
+        "typescript": "6.0.3",
         "vite": "8.0.16",
         "vitest": "4.1.8"
       },
@@ -1809,9 +1809,9 @@
       "license": "0BSD"
     },
     "node_modules/typescript": {
-      "version": "5.9.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
-      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
   "devDependencies": {
     "@biomejs/biome": "2.4.16",
     "@types/node": "24.13.0",
-    "typescript": "5.9.3",
+    "typescript": "6.0.3",
     "vite": "8.0.16",
     "vitest": "4.1.8"
   },

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -16,9 +16,8 @@
     "exactOptionalPropertyTypes": false,
     "outDir": "dist",
     "types": ["vitest/globals"],
-    "baseUrl": ".",
     "paths": {
-      "@/*": ["src/*"]
+      "@/*": ["./src/*"]
     }
   },
   "include": ["src/**/*.ts", "index.ts", "vite.config.ts", "vitest.config.ts"],


### PR DESCRIPTION
## Summary

- `typescript` 5.9.3 → 6.0.3 (pinned exactly)

This was the only remaining major bump available — `@types/node` is intentionally held at v24 to match the Node runtime declared in `package.json` (`"engines": { "node": ">=24.0.0" }`).

## Breaking-change fixes

- Drop the deprecated `baseUrl` from `tsconfig.json` (TS5101 in TS 6)
- Update the `@/*` path alias to use a relative target (`./src/*`) so it resolves without `baseUrl`

## Test plan

- [x] `npm run typecheck` — passes on TS 6
- [x] `npm run build` — passes (vite 8)
- [x] `npm run lint` — passes
- [x] `npm test` — 52/52 pass
- [ ] CI to verify