### PR TITLE
ci: add Gate aggregator check to pull-request workflow

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -164,3 +164,39 @@ jobs:
         uses: github/codeql-action/upload-sarif@v4
         with:
           sarif_file: trivy-results.sarif
+
+  # ==============================================
+  # Gate
+  # ==============================================
+  # Single aggregator check every PR must pass. Branch protection requires the
+  # "Gate" status, so required checks stay stable even as the jobs below change.
+  gate:
+    name: Gate
+    if: always()
+    needs:
+      - build
+      - lint
+      - opentofu
+      - gitleaks
+      - bearer
+      - opentofu-security
+    runs-on: ubuntu-latest
+    timeout-minutes: 1
+    steps:
+      - name: Check results
+        run: |
+          results=(
+            "${{ needs.build.result }}"
+            "${{ needs.lint.result }}"
+            "${{ needs.opentofu.result }}"
+            "${{ needs.gitleaks.result }}"
+            "${{ needs.bearer.result }}"
+            "${{ needs.opentofu-security.result }}"
+          )
+          for r in "${results[@]}"; do
+            if [ "$r" = "failure" ] || [ "$r" = "cancelled" ]; then
+              echo "One or more jobs failed or were cancelled."
+              exit 1
+            fi
+          done
+          echo "All jobs passed or were skipped."


### PR DESCRIPTION
Add a single Gate job that needs all existing PR jobs (build, lint, opentofu, gitleaks, bearer, opentofu-security) and fails if any failed or was cancelled. Gives one stable required-status-check for branch protection managed in the home-infra github stack.