### PR TITLE
fix(deploy): use scoped OIDC role and @main reusable workflow refs

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -21,7 +21,7 @@ env:
 jobs:
   notify-start:
     name: Notify Deployment Start
-    uses: domengabrovsek/github-actions/.github/workflows/send-telegram-message.yml@master
+    uses: domengabrovsek/github-actions/.github/workflows/send-telegram-message.yml@main
     with:
       api_url: ${{ vars.TELEGRAM_API_URL }}
       chat_id: ${{ vars.TELEGRAM_CHAT_ID }}
@@ -58,14 +58,11 @@ jobs:
     - name: Build application
       run: npm run build
 
-    # Configure AWS credentials using IAM role or access keys
+    # Assume the scoped OIDC deploy role (hub-managed, least-privilege)
     - name: Setup AWS credentials
       uses: aws-actions/configure-aws-credentials@v6
       with:
-        # Use IAM role if TERRAFORM_ROLE is set, otherwise fall back to access keys
-        role-to-assume: ${{ secrets.TERRAFORM_ROLE }}
-        aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-        aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+        role-to-assume: ${{ vars.AWS_DEPLOY_ROLE_ARN }}
         aws-region: ${{ env.AWS_REGION }}
 
     # Setup OpenTofu CLI
@@ -124,7 +121,7 @@ jobs:
     name: Notify Deployment Success
     needs: deploy
     if: success()
-    uses: domengabrovsek/github-actions/.github/workflows/send-telegram-message.yml@master
+    uses: domengabrovsek/github-actions/.github/workflows/send-telegram-message.yml@main
     with:
       api_url: ${{ vars.TELEGRAM_API_URL }}
       chat_id: ${{ vars.TELEGRAM_CHAT_ID }}
@@ -142,7 +139,7 @@ jobs:
     name: Notify Deployment Failure
     needs: deploy
     if: failure()
-    uses: domengabrovsek/github-actions/.github/workflows/send-telegram-message.yml@master
+    uses: domengabrovsek/github-actions/.github/workflows/send-telegram-message.yml@main
     with:
       api_url: ${{ vars.TELEGRAM_API_URL }}
       chat_id: ${{ vars.TELEGRAM_CHAT_ID }}


### PR DESCRIPTION
## Summary

- Point the three `send-telegram-message.yml@master` reusable-workflow calls at `@main`.
- Switch AWS auth in `deploy.yml` from `secrets.TERRAFORM_ROLE` (+ dead static-key fallback) to the hub-managed `vars.AWS_DEPLOY_ROLE_ARN`.

## Why

- The shared `github-actions` repo was renamed `master`->`main`, so the `@master` reusable-workflow refs no longer resolve - the last deploy failed at the workflow-parse stage before any job ran.
- `vars.AWS_DEPLOY_ROLE_ARN` now resolves to a dedicated least-privilege `telegram-notify-bot-deploy` OIDC role scoped to this app's terraform footprint (Lambda, API Gateway, SQS, SSM, logs, EventBridge, its own IAM roles, its state key), replacing the broad shared click-ops role. The static access keys were already removed from repo secrets and are unused.

## Verification

- Merging to `main` triggers the deploy; it should run green end-to-end on the new role (OpenTofu plan/apply over `./terraform`, no changes expected since the infra is already live).