### PR TITLE
feat: replace API Gateway + SQS with a Lambda Function URL

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -112,7 +112,7 @@ jobs:
     - name: Get webhook URL
       working-directory: ./terraform
       run: |
-        WEBHOOK_URL=$(tofu output -raw api_gateway_invoke_url)
+        WEBHOOK_URL=$(tofu output -raw webhook_url)
         echo "WEBHOOK_URL=$WEBHOOK_URL" >> $GITHUB_ENV
         echo "✅ Webhook URL configured (masked for security)"
 

--- a/src/__tests__/handler.test.ts
+++ b/src/__tests__/handler.test.ts
@@ -8,6 +8,13 @@ import { processMessage } from '@/services/message-processor';
 
 const mockProcessMessage = vi.mocked(processMessage);
 
+const functionUrlEvent = (body: string | undefined, isBase64Encoded = false) => ({
+  version: '2.0',
+  requestContext: { http: { method: 'POST' } },
+  body,
+  isBase64Encoded,
+});
+
 beforeEach(() => {
   vi.clearAllMocks();
 });
@@ -25,42 +32,44 @@ describe('handler', () => {
     });
   });
 
-  describe('SQS events', () => {
-    it('processes all records successfully', async () => {
+  describe('Function URL events', () => {
+    it('processes the request body and returns 200', async () => {
+      mockProcessMessage.mockResolvedValue();
+      const body = '{"message":{"text":"hello"},"chat_id":"123"}';
+
+      const result = await handler(functionUrlEvent(body));
+
+      expect(result).toEqual({ statusCode: 200, body: JSON.stringify({ ok: true }) });
+      expect(mockProcessMessage).toHaveBeenCalledWith(body);
+    });
+
+    it('decodes a base64-encoded body before processing', async () => {
+      mockProcessMessage.mockResolvedValue();
+      const body = '{"message":{"text":"hi"},"chat_id":"456"}';
+      const encoded = Buffer.from(body, 'utf-8').toString('base64');
+
+      const result = await handler(functionUrlEvent(encoded, true));
+
+      expect(result).toEqual({ statusCode: 200, body: JSON.stringify({ ok: true }) });
+      expect(mockProcessMessage).toHaveBeenCalledWith(body);
+    });
+
+    it('still returns 200 when processing throws (no queue retry)', async () => {
+      mockProcessMessage.mockRejectedValue(new Error('send failed'));
+
+      const result = await handler(functionUrlEvent('{"invalid":true}'));
+
+      expect(result).toEqual({ statusCode: 200, body: JSON.stringify({ ok: true }) });
+      expect(mockProcessMessage).toHaveBeenCalledTimes(1);
+    });
+
+    it('processes an empty body as an empty string', async () => {
       mockProcessMessage.mockResolvedValue();
 
-      const result = await handler({
-        Records: [
-          { messageId: 'msg-1', body: '{"message":{"text":"hello"},"chat_id":"123"}', eventSource: 'aws:sqs' },
-          { messageId: 'msg-2', body: '{"message":{"text":"world"},"chat_id":"456"}', eventSource: 'aws:sqs' },
-        ],
-      });
+      const result = await handler(functionUrlEvent(undefined));
 
-      expect(result).toEqual({ batchItemFailures: [] });
-      expect(mockProcessMessage).toHaveBeenCalledTimes(2);
-    });
-
-    it('reports failed records as batch item failures', async () => {
-      mockProcessMessage.mockResolvedValueOnce();
-      mockProcessMessage.mockRejectedValueOnce(new Error('send failed'));
-
-      const result = await handler({
-        Records: [
-          { messageId: 'msg-1', body: '{"message":{"text":"ok"},"chat_id":"123"}', eventSource: 'aws:sqs' },
-          { messageId: 'msg-2', body: 'invalid', eventSource: 'aws:sqs' },
-        ],
-      });
-
-      expect(result).toEqual({
-        batchItemFailures: [{ itemIdentifier: 'msg-2' }],
-      });
-    });
-
-    it('handles empty records array', async () => {
-      const result = await handler({ Records: [] });
-
-      expect(result).toEqual({ batchItemFailures: [] });
-      expect(mockProcessMessage).not.toHaveBeenCalled();
+      expect(result).toEqual({ statusCode: 200, body: JSON.stringify({ ok: true }) });
+      expect(mockProcessMessage).toHaveBeenCalledWith('');
     });
   });
 

--- a/src/handler.ts
+++ b/src/handler.ts
@@ -1,30 +1,28 @@
 import { processMessage } from '@/services/message-processor';
-import type { LambdaEvent, SQSBatchResponse } from '@/types';
+import type { LambdaEvent } from '@/types';
 
-// Lambda entry point. Routes SQS messages to the processor and handles EventBridge warmup pings.
-export async function handler(event: LambdaEvent): Promise<SQSBatchResponse | { statusCode: number; body: string }> {
+/* Lambda entry point. Handles Telegram webhook / direct-API POSTs delivered via
+   the Lambda Function URL, plus EventBridge warmup pings. */
+export async function handler(event: LambdaEvent): Promise<{ statusCode: number; body: string }> {
   // EventBridge warmup ping - return immediately without any processing
   if ('source' in event && event.source === 'aws.events') {
     return { statusCode: 200, body: JSON.stringify({ message: 'warmup' }) };
   }
 
-  // SQS batch processing with partial failure reporting
-  if ('Records' in event) {
-    const failures: Array<{ itemIdentifier: string }> = [];
+  // Function URL HTTP request (Telegram webhook or direct API call)
+  if ('requestContext' in event) {
+    const rawBody =
+      event.isBase64Encoded && event.body ? Buffer.from(event.body, 'base64').toString('utf-8') : (event.body ?? '');
 
-    for (const record of event.Records) {
-      try {
-        await processMessage(record.body);
-      } catch (error) {
-        console.error(
-          `Failed to process message ${record.messageId}:`,
-          error instanceof Error ? error.message : 'Unknown error',
-        );
-        failures.push({ itemIdentifier: record.messageId });
-      }
+    try {
+      await processMessage(rawBody);
+    } catch (error) {
+      /* No SQS/DLQ backs the Function URL, so a failure is logged here and the
+         request still returns 200 - Telegram retries webhooks on any non-2xx. */
+      console.error('Failed to process message:', error instanceof Error ? error.message : 'Unknown error');
     }
 
-    return { batchItemFailures: failures };
+    return { statusCode: 200, body: JSON.stringify({ ok: true }) };
   }
 
   return { statusCode: 400, body: JSON.stringify({ error: 'Invalid event' }) };

--- a/src/services/message-processor.ts
+++ b/src/services/message-processor.ts
@@ -3,8 +3,8 @@ import { getTelegramConfig } from '@/services/config';
 import { sendMessage } from '@/services/telegram-client';
 import { extractMessageText, parseAndValidateBody } from '@/validators/message-validator';
 
-// Processes a single raw message body from the SQS queue.
-// Handles both Telegram webhook updates and direct API calls.
+/* Processes a single raw message body from a Function URL request.
+   Handles both Telegram webhook updates and direct API calls. */
 export async function processMessage(rawBody: string): Promise<void> {
   const config = await getTelegramConfig();
   const body = parseAndValidateBody(rawBody);

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,23 +1,22 @@
-// SQS event types for Lambda invocation
-export interface SQSRecord {
-  messageId: string;
-  body: string;
-  eventSource: string;
-}
-
-export interface SQSEvent {
-  Records: SQSRecord[];
-}
-
-export interface SQSBatchResponse {
-  batchItemFailures: Array<{ itemIdentifier: string }>;
-}
-
+// EventBridge warmup ping
 export interface WarmupEvent {
   source?: string;
 }
 
-export type LambdaEvent = SQSEvent | WarmupEvent;
+/* Lambda Function URL request (payload format 2.0), trimmed to the fields the
+   handler reads. Telegram and the notify workflows POST the message body here. */
+export interface FunctionUrlEvent {
+  version: string;
+  requestContext: {
+    http: {
+      method: string;
+    };
+  };
+  body?: string;
+  isBase64Encoded?: boolean;
+}
+
+export type LambdaEvent = WarmupEvent | FunctionUrlEvent;
 
 // Telegram webhook/API message structure
 export interface TelegramFrom {

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -150,27 +150,6 @@ resource "aws_iam_role_policy" "lambda_ssm_access" {
   })
 }
 
-# SQS Dead Letter Queue for failed messages
-resource "aws_sqs_queue" "telegram_dlq" {
-  name                      = "${var.project_name}-dlq"
-  message_retention_seconds = 1209600 # 14 days
-  tags                      = var.tags
-}
-
-# SQS Queue for buffering incoming messages
-resource "aws_sqs_queue" "telegram_queue" {
-  name                       = "${var.project_name}-queue"
-  visibility_timeout_seconds = 60    # 4x Lambda timeout
-  message_retention_seconds  = 86400 # 1 day
-  receive_wait_time_seconds  = 20    # long polling
-  tags                       = var.tags
-
-  redrive_policy = jsonencode({
-    deadLetterTargetArn = aws_sqs_queue.telegram_dlq.arn
-    maxReceiveCount     = 3
-  })
-}
-
 # Lambda function
 resource "aws_lambda_function" "telegram_bot" {
   filename         = data.archive_file.lambda_zip.output_path
@@ -198,46 +177,11 @@ resource "aws_lambda_function" "telegram_bot" {
   depends_on = [
     aws_iam_role_policy_attachment.lambda_basic_execution,
     aws_iam_role_policy.lambda_ssm_access,
-    aws_iam_role_policy.lambda_sqs_access,
     aws_cloudwatch_log_group.lambda_logs,
     aws_ssm_parameter.bot_token,
     aws_ssm_parameter.admin_chat_id,
     aws_ssm_parameter.additional_chat_ids,
   ]
-}
-
-# IAM policy for Lambda to consume from SQS
-resource "aws_iam_role_policy" "lambda_sqs_access" {
-  name = "${var.project_name}-sqs-access"
-  role = aws_iam_role.lambda_role.id
-
-  policy = jsonencode({
-    Version = "2012-10-17"
-    Statement = [
-      {
-        Sid    = "AllowSQSConsume"
-        Effect = "Allow"
-        Action = [
-          "sqs:ReceiveMessage",
-          "sqs:DeleteMessage",
-          "sqs:GetQueueAttributes"
-        ]
-        Resource = [
-          aws_sqs_queue.telegram_queue.arn,
-          aws_sqs_queue.telegram_dlq.arn
-        ]
-      }
-    ]
-  })
-}
-
-# SQS -> Lambda event source mapping
-resource "aws_lambda_event_source_mapping" "sqs_trigger" {
-  event_source_arn                   = aws_sqs_queue.telegram_queue.arn
-  function_name                      = aws_lambda_function.telegram_bot.arn
-  batch_size                         = 1
-  function_response_types            = ["ReportBatchItemFailures"]
-  maximum_batching_window_in_seconds = 0
 }
 
 # CloudWatch Log Group
@@ -247,187 +191,27 @@ resource "aws_cloudwatch_log_group" "lambda_logs" {
   tags              = var.tags
 }
 
-# API Gateway REST API
-resource "aws_api_gateway_rest_api" "telegram_api" {
-  name        = "${var.project_name}-api"
-  description = "Webhook API for ${var.project_name}"
-
-  endpoint_configuration {
-    types = ["REGIONAL"]
-  }
-
-  tags = var.tags
-
-  # Ensure proper deletion order
-  lifecycle {
-    create_before_destroy = false
-  }
+/* Public Lambda Function URL - the Telegram webhook + notify-workflow ingestion
+   endpoint, replacing the former API Gateway -> SQS path. Unauthenticated at the
+   edge (Telegram cannot sign requests); the handler authorizes by chat id. */
+resource "aws_lambda_function_url" "telegram_bot" {
+  function_name      = aws_lambda_function.telegram_bot.function_name
+  authorization_type = "NONE"
 }
 
-# API Gateway Resource
-resource "aws_api_gateway_resource" "webhook" {
-  rest_api_id = aws_api_gateway_rest_api.telegram_api.id
-  parent_id   = aws_api_gateway_rest_api.telegram_api.root_resource_id
-  path_part   = "webhook"
+# Allow public unauthenticated invokes of the Function URL (Telegram + notify workflows).
+resource "aws_lambda_permission" "function_url" {
+  statement_id           = "AllowPublicFunctionUrlInvoke"
+  action                 = "lambda:InvokeFunctionUrl"
+  function_name          = aws_lambda_function.telegram_bot.function_name
+  principal              = "*"
+  function_url_auth_type = "NONE"
 }
-
-# API Gateway Method
-resource "aws_api_gateway_method" "webhook_post" {
-  rest_api_id   = aws_api_gateway_rest_api.telegram_api.id
-  resource_id   = aws_api_gateway_resource.webhook.id
-  http_method   = "POST"
-  authorization = "NONE"
-
-  # Request validation
-  request_validator_id = aws_api_gateway_request_validator.webhook_validator.id
-
-  # Require JSON content type
-  request_models = {
-    "application/json" = "Empty"
-  }
-}
-
-# Request validator
-resource "aws_api_gateway_request_validator" "webhook_validator" {
-  name                        = "${var.project_name}-validator"
-  rest_api_id                 = aws_api_gateway_rest_api.telegram_api.id
-  validate_request_body       = true
-  validate_request_parameters = true
-}
-
-# IAM role for API Gateway -> SQS
-resource "aws_iam_role" "api_gateway_sqs_role" {
-  name        = "${var.project_name}-apigw-sqs-role"
-  description = "Allows API Gateway to send messages to SQS for ${var.project_name}"
-  tags        = var.tags
-
-  assume_role_policy = jsonencode({
-    Version = "2012-10-17"
-    Statement = [
-      {
-        Effect = "Allow"
-        Principal = {
-          Service = "apigateway.amazonaws.com"
-        }
-        Action = "sts:AssumeRole"
-      }
-    ]
-  })
-}
-
-resource "aws_iam_role_policy" "api_gateway_sqs_send" {
-  name = "${var.project_name}-apigw-sqs-send"
-  role = aws_iam_role.api_gateway_sqs_role.id
-
-  policy = jsonencode({
-    Version = "2012-10-17"
-    Statement = [
-      {
-        Effect   = "Allow"
-        Action   = "sqs:SendMessage"
-        Resource = aws_sqs_queue.telegram_queue.arn
-      }
-    ]
-  })
-}
-
-# API Gateway Integration - sends request body to SQS
-resource "aws_api_gateway_integration" "lambda_integration" {
-  rest_api_id             = aws_api_gateway_rest_api.telegram_api.id
-  resource_id             = aws_api_gateway_resource.webhook.id
-  http_method             = aws_api_gateway_method.webhook_post.http_method
-  integration_http_method = "POST"
-  type                    = "AWS"
-  uri                     = "arn:aws:apigateway:${var.aws_region}:sqs:path/${data.aws_caller_identity.current.account_id}/${aws_sqs_queue.telegram_queue.name}"
-  credentials             = aws_iam_role.api_gateway_sqs_role.arn
-
-  request_parameters = {
-    "integration.request.header.Content-Type" = "'application/x-www-form-urlencoded'"
-  }
-
-  request_templates = {
-    "application/json" = "Action=SendMessage&MessageBody=$util.urlEncode($input.body)"
-  }
-}
-
-# Method response for 200 OK
-resource "aws_api_gateway_method_response" "webhook_200" {
-  rest_api_id = aws_api_gateway_rest_api.telegram_api.id
-  resource_id = aws_api_gateway_resource.webhook.id
-  http_method = aws_api_gateway_method.webhook_post.http_method
-  status_code = "200"
-
-  response_models = {
-    "application/json" = "Empty"
-  }
-}
-
-# Integration response - maps SQS success to 200
-resource "aws_api_gateway_integration_response" "webhook_200" {
-  rest_api_id = aws_api_gateway_rest_api.telegram_api.id
-  resource_id = aws_api_gateway_resource.webhook.id
-  http_method = aws_api_gateway_method.webhook_post.http_method
-  status_code = aws_api_gateway_method_response.webhook_200.status_code
-
-  response_templates = {
-    "application/json" = "{\"message\": \"queued\"}"
-  }
-
-  depends_on = [aws_api_gateway_integration.lambda_integration]
-}
-
-# API Gateway Deployment
-resource "aws_api_gateway_deployment" "telegram_deployment" {
-  rest_api_id = aws_api_gateway_rest_api.telegram_api.id
-  description = "Auto-redeployed on API configuration changes"
-
-  triggers = {
-    redeployment = sha1(jsonencode([
-      aws_api_gateway_resource.webhook.id,
-      aws_api_gateway_method.webhook_post.id,
-      aws_api_gateway_integration.lambda_integration.id,
-      aws_api_gateway_method_response.webhook_200.id,
-      aws_api_gateway_integration_response.webhook_200.id,
-    ]))
-  }
-
-  lifecycle {
-    create_before_destroy = true
-  }
-
-  depends_on = [aws_api_gateway_method.webhook_post, aws_api_gateway_integration.lambda_integration, aws_api_gateway_integration_response.webhook_200]
-}
-
-# API Gateway Stage
-resource "aws_api_gateway_stage" "telegram_stage" {
-  deployment_id = aws_api_gateway_deployment.telegram_deployment.id
-  rest_api_id   = aws_api_gateway_rest_api.telegram_api.id
-  stage_name    = var.stage_name
-  description   = "Production stage with throttling and error-only logging"
-  tags          = var.tags
-}
-
-# Method throttling settings
-resource "aws_api_gateway_method_settings" "webhook_throttling" {
-  rest_api_id = aws_api_gateway_rest_api.telegram_api.id
-  stage_name  = aws_api_gateway_stage.telegram_stage.stage_name
-  method_path = "${aws_api_gateway_resource.webhook.path_part}/${aws_api_gateway_method.webhook_post.http_method}"
-
-  settings {
-    throttling_rate_limit  = 20      # requests per second (headroom for burst traffic)
-    throttling_burst_limit = 40      # burst capacity (allows concurrent deployments)
-    logging_level          = "ERROR" # Only log errors to minimize CloudWatch costs
-    data_trace_enabled     = false   # Disable to reduce costs
-    metrics_enabled        = false   # Disable to reduce costs (can enable if needed)
-  }
-}
-
-# API Gateway CloudWatch log group removed to minimize costs (access logging disabled)
 
 # Register webhook with Telegram after deployment
 resource "null_resource" "register_webhook" {
   triggers = {
-    webhook_url = "https://${aws_api_gateway_rest_api.telegram_api.id}.execute-api.${var.aws_region}.amazonaws.com/${var.stage_name}/webhook"
+    webhook_url = aws_lambda_function_url.telegram_bot.function_url
   }
 
   provisioner "local-exec" {
@@ -436,11 +220,11 @@ resource "null_resource" "register_webhook" {
       TOKEN=$(aws ssm get-parameter --name "/telegram-notify-bot/bot-token" --with-decryption --query 'Parameter.Value' --output text --region ${var.aws_region})
       RESPONSE=$(curl -s -X POST "https://api.telegram.org/bot$TOKEN/setWebhook" \
         -H "Content-Type: application/json" \
-        -d '{"url": "https://${aws_api_gateway_rest_api.telegram_api.id}.execute-api.${var.aws_region}.amazonaws.com/${var.stage_name}/webhook"}')
+        -d '{"url": "${aws_lambda_function_url.telegram_bot.function_url}"}')
 
       if echo "$RESPONSE" | grep -q '"ok":true'; then
         echo "✅ Webhook registered successfully!"
-        echo "Webhook URL: https://${aws_api_gateway_rest_api.telegram_api.id}.execute-api.${var.aws_region}.amazonaws.com/${var.stage_name}/webhook"
+        echo "Webhook URL: ${aws_lambda_function_url.telegram_bot.function_url}"
       else
         echo "❌ Failed to register webhook:"
         echo "$RESPONSE"
@@ -449,10 +233,7 @@ resource "null_resource" "register_webhook" {
     EOT
   }
 
-  depends_on = [
-    aws_api_gateway_deployment.telegram_deployment,
-    aws_api_gateway_stage.telegram_stage,
-  ]
+  depends_on = [aws_lambda_function_url.telegram_bot]
 }
 
 # EventBridge rule to keep Lambda warm (every 5 minutes)

--- a/terraform/outputs.tf
+++ b/terraform/outputs.tf
@@ -1,6 +1,6 @@
-output "api_gateway_invoke_url" {
-  description = "Invoke URL for the API Gateway webhook"
-  value       = "https://${aws_api_gateway_rest_api.telegram_api.id}.execute-api.${var.aws_region}.amazonaws.com/${var.stage_name}/webhook"
+output "webhook_url" {
+  description = "Public Lambda Function URL registered as the Telegram webhook"
+  value       = aws_lambda_function_url.telegram_bot.function_url
   sensitive   = true
 }
 
@@ -8,14 +8,4 @@ output "lambda_function_name" {
   description = "Name of the Lambda function"
   value       = aws_lambda_function.telegram_bot.function_name
   sensitive   = true
-}
-
-output "sqs_queue_url" {
-  description = "URL of the SQS queue for message buffering"
-  value       = aws_sqs_queue.telegram_queue.url
-}
-
-output "sqs_dlq_url" {
-  description = "URL of the SQS dead letter queue for failed messages"
-  value       = aws_sqs_queue.telegram_dlq.url
 }


### PR DESCRIPTION
## Summary

- Simplify the bot to the shupak-bot pattern: Telegram and the notify workflows POST directly to a **public Lambda Function URL** instead of going through API Gateway -> SQS -> Lambda.
- Terraform: remove the REST API (11 resources), the SQS queue + DLQ, the SQS event-source-mapping, the Lambda SQS-consume policy, and the apigw->SQS IAM role; add `aws_lambda_function_url` + a public `InvokeFunctionUrl` permission; register the webhook against the Function URL.
- Handler: parse the Function URL HTTP event (base64-aware) instead of SQS batch records. `processMessage` and the request/response contract are unchanged, so the notify workflows keep working without changes.
- `outputs.tf`: replace the API Gateway / SQS outputs with `webhook_url`; `deploy.yml` reads the new output name.

## Trade-off

- No queue buffering, DLQ, or automatic retry. Processing failures are logged and the webhook still returns 200 (Telegram retries on non-2xx, which we intentionally avoid). Accepted for the simplification.

## Verification

- `npm run typecheck`, `npm test` (53 pass), `npm run build`, and `tofu validate` all pass locally.
- Post-merge deploy will destroy the API Gateway/SQS resources, create the Function URL, and re-register the Telegram webhook. The `TELEGRAM_API_URL` hub variable is repointed to the new URL separately.