### PR TITLE
ci: centralize deploy Node setup onto shared composite action

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -39,20 +39,11 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    # Checkout repository code
-    - name: Checkout
-      uses: actions/checkout@v7
-
-    # Setup Node.js using version from .nvmrc file (Node 24)
-    - name: Setup Node.js
-      uses: actions/setup-node@v6
+    # Checkout, setup Node from .nvmrc, and npm ci via the shared hub action
+    - name: Setup Node and install dependencies
+      uses: domengabrovsek/github-actions/.github/actions/setup-node-npm@main
       with:
-        node-version-file: .nvmrc
-        cache: 'npm'
-
-    # Install dependencies using npm ci for faster, reliable builds
-    - name: Install dependencies
-      run: npm ci --ignore-scripts --no-progress --audit=false
+        install-args: --ignore-scripts --no-progress --audit=false
 
     # Build TypeScript code for Lambda deployment
     - name: Build application


### PR DESCRIPTION
- Replaces the three consecutive steps in the deploy job (actions/checkout, actions/setup-node@v6, npm ci) with a single call to the shared hub composite domengabrovsek/github-actions/.github/actions/setup-node-npm@main
- Moves setup-node version management into the hub instead of per-repo, so the standing Dependabot bumps for setup-node in this file no longer occur
- npm ci flags preserved via install-args: --ignore-scripts --no-progress --audit=false
- Node version still resolved from .nvmrc (composite default), npm cache still enabled
- Supersedes Dependabot PR #89 by removing the direct setup-node reference this workflow no longer pins
- Net change: 4 insertions, 13 deletions

Everything else in the workflow is unchanged: triggers, permissions, env, the notify-start/notify-success/notify-failure jobs, and the build/OpenTofu/deploy steps.