### PR TITLE
ci: drop redundant npm ci install-args (now baseline in hub)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -42,8 +42,6 @@ jobs:
     # Checkout, setup Node from .nvmrc, and npm ci via the shared hub action
     - name: Setup Node and install dependencies
       uses: domengabrovsek/github-actions/.github/actions/setup-node-npm@main
-      with:
-        install-args: --ignore-scripts --no-progress --audit=false
 
     # Build TypeScript code for Lambda deployment
     - name: Build application

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -33,7 +33,6 @@ jobs:
       test_command: npm run test
       build_command: npm run build
       build_artifact_path: dist/index.mjs
-      install-args: --ignore-scripts
 
   # ==============================================
   # OpenTofu Validation


### PR DESCRIPTION
Drop the per-repo npm ci install-args that are now redundant: the hub's setup-node-npm composite and node-ci both run `npm ci --ignore-scripts --no-audit --no-fund` as the baseline. No behavior change - the flags are already applied centrally.

Part of the CI consolidation cleanup so each repo passes install-args only when it has a genuine extra.