### PR TITLE
docs: rewrite README against the deployed Function URL architecture

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,68 +1,75 @@
-# Telegram Notify Bot
+# telegram-notify-bot 🤖
 
-Serverless Telegram bot for sending notifications. Receives messages via an HTTP webhook, buffers them through SQS, and delivers them via the Telegram Bot API. Deployed to AWS with OpenTofu.
+Sends me a Telegram message when something in my repos needs attention. One Lambda behind a public Function URL: POST a chat ID and some text, it forwards to the Telegram Bot API. The notification workflows in [domengabrovsek/github-actions](https://github.com/domengabrovsek/github-actions) are its main caller.
 
-## Architecture
+## How it works
 
 ```mermaid
 flowchart LR
-    Caller[HTTP Client]
-    APIGW[API Gateway]
-    SQS[(SQS)]
+    Caller[GitHub Actions / curl]
+    URL[Lambda Function URL]
     Lambda[Lambda]
-    Telegram[Telegram API]
+    SSM[SSM Parameter Store]
+    Telegram[Telegram Bot API]
+    EB[EventBridge]
 
-    Caller -- POST /webhook --> APIGW
-    APIGW --> SQS
-    SQS --> Lambda
-    Lambda --> Telegram
+    Caller -- POST --> URL
+    URL --> Lambda
+    Lambda -- token + chat IDs, cached 24h --> SSM
+    Lambda -- retry with backoff --> Telegram
+    EB -- ping every 5 min --> Lambda
 ```
 
-API Gateway receives webhooks and forwards them to an SQS queue. Lambda processes messages from the queue with retry logic and exponential backoff. A dead letter queue captures messages that fail after 3 attempts. EventBridge pings Lambda every 5 minutes to avoid cold starts.
+The Function URL is unauthenticated at the edge because Telegram cannot sign its webhook calls. Authorization happens in the handler instead: only chat IDs on the allowlist get a message delivered, everything else is dropped and the admin chat gets an alert with the caller's details. Bot token and chat IDs live in SSM as encrypted parameters, read once per container and cached for 24 hours.
 
-## Quick Start
+The same endpoint takes both kinds of traffic: Telegram webhook updates (registered automatically on deploy) and direct API calls from CI. Webhook updates are never echoed back, so messaging the bot does nothing except trip an alert if you are not on the allowlist.
+
+## Sending a message
+
+```bash
+curl -X POST "$WEBHOOK_URL" \
+  -H "Content-Type: application/json" \
+  -d '{"chat_id": "123456789", "message": {"text": "Deploy finished"}}'
+```
+
+Plain text only, 4096 characters max. The endpoint always answers `200` so Telegram does not queue retries, which means a rejected or failed send shows up in CloudWatch, not in the response. Telegram 429s and 5xx are retried twice with exponential backoff.
+
+## Deploying
+
+You need an AWS account, [OpenTofu](https://opentofu.org) 1.6+, Node 24, an S3 bucket for state, and a bot token from [@BotFather](https://t.me/botfather).
 
 ```bash
 npm install
-npm run build
+npm run build                                   # dist/index.mjs is what OpenTofu zips
 cd terraform
+cp terraform.tfvars.example terraform.tfvars    # bot token, chat IDs, state bucket
+cp backend.hcl.example backend.hcl              # state bucket + region
 tofu init -backend-config=backend.hcl
-tofu apply
+tofu apply                                      # also calls setWebhook with the new URL
 ```
 
-See [docs/setup.md](docs/setup.md) for the full setup guide.
+`tofu apply` prints the Function URL as a sensitive output (`tofu output webhook_url`). Deploys also run from GitHub Actions on push to `main`. Full walkthrough, including how to find your chat ID: [docs/setup.md](docs/setup.md).
 
-## Usage
-
-Send notifications via HTTP POST:
+## Scripts
 
 ```bash
-curl -X POST "https://your-api-url/webhook" \
-  -H "Content-Type: application/json" \
-  -d '{"chat_id": "YOUR_CHAT_ID", "message": {"text": "Deployment completed!"}}'
+npm run build        # bundle the Lambda with vite
+npm run dev          # rebuild on change
+npm run test         # vitest
+npm run typecheck    # tsc --noEmit
+npm run lint         # biome check
+npm run lint:fix     # biome check --write
+npm run tofu:plan    # preview infrastructure changes
+npm run tofu:apply   # deploy
+npm run tofu:destroy # tear it all down
 ```
 
-## Development
+## Docs
 
-```bash
-npm run build        # Build Lambda bundle
-npm run dev          # Watch mode
-npm run test         # Run tests
-npm run typecheck    # TypeScript type check
-npm run lint         # Biome lint & format check
-npm run lint:fix     # Auto-fix lint issues
-npm run tofu:init    # Initialize OpenTofu backend
-npm run tofu:plan    # Preview infrastructure changes
-npm run tofu:apply   # Deploy infrastructure
-npm run tofu:destroy # Tear down infrastructure
-```
-
-## Documentation
-
-- [Architecture](docs/architecture.md) - system design, AWS resources, IAM requirements
+- [Architecture](docs/architecture.md) - AWS resources, IAM, request flow
 - [Configuration](docs/configuration.md) - OpenTofu variables, GitHub Actions secrets
-- [Setup](docs/setup.md) - prerequisites, Telegram bot creation, deployment steps
-- [CI/CD](docs/ci-cd.md) - GitHub Actions workflows, authentication setup
+- [Setup](docs/setup.md) - bot creation, chat ID, first deploy
+- [CI/CD](docs/ci-cd.md) - workflows and OIDC authentication
 
 ## License
 


### PR DESCRIPTION
## Summary

- Rewrites the README in the same plain, practical style as the `github-actions` repo: what the bot is for, how a request flows, how to call it, how to deploy it
- Corrects the architecture description - the README (and the mermaid diagram) claimed API Gateway plus SQS plus a DLQ, none of which exist in `terraform/main.tf`. The real path is a public Lambda Function URL straight into the handler
- Explains why the Function URL is unauthenticated and where authorization actually happens (chat ID allowlist in the handler, security alert to the admin chat otherwise)
- Adds behavior a caller needs to know: SSM parameter caching, retry with backoff on 429/5xx, the 4096 character limit, and the always-200 response
- Fills in the two deploy steps that were missing: copying `backend.hcl.example` and reading the URL back with `tofu output webhook_url`

Repo description and topics were updated separately via `gh repo edit` (dropped `api-gateway`, added `opentofu`).

## Follow-up

`docs/architecture.md` still documents the old API Gateway plus SQS plus DLQ design and needs the same correction.